### PR TITLE
Preparing to Keychain Item Import

### DIFF
--- a/lib/keychain/key.rb
+++ b/lib/keychain/key.rb
@@ -56,6 +56,12 @@ module Sec
   end
 
   attach_function 'SecItemExport', [:pointer, :SecExternalFormat, :SecItemImportExportFlags, :pointer, :pointer], :osstatus
+  attach_function 'SecItemImport', [:pointer, :pointer,
+                                    :SecExternalFormat,
+                                    :SecExternalItemType,
+                                    :SecItemImportExportFlags,
+                                    :pointer, :pointer, :pointer], :osstatus
+
 end
 
 class Keychain::Key < Sec::Base

--- a/lib/keychain/keychain.rb
+++ b/lib/keychain/keychain.rb
@@ -7,6 +7,9 @@ module Sec
                               :kSecItemTypeCertificate,
                               :kSecItemTypeAggregate]
 
+  attach_function 'SecAccessCreate', [:pointer, :pointer, :pointer], :osstatus
+  attach_function 'SecTrustedApplicationCreateFromPath', [:string, :pointer], :osstatus
+
   attach_function 'SecKeychainCopyDefault', [:pointer], :osstatus
   attach_function 'SecKeychainDelete', [:keychainref], :osstatus
   attach_function 'SecKeychainOpen', [:string, :pointer], :osstatus
@@ -24,6 +27,14 @@ module Sec
             :lock_on_sleep, :uchar,
             :use_lock_interval, :uchar, #apple ignores this
             :lock_interval, :uint32
+  end
+
+  class Keychain::TrustedApplication < Sec::Base
+    register_type 'SecTrustedApplication'
+  end
+
+  class Keychain::Access < Sec::Base
+    register_type 'SecAccess'
   end
 
   attach_function 'SecKeychainSetSettings', [:keychainref, KeychainSettings], :osstatus
@@ -107,6 +118,38 @@ module Keychain
     # @return [Keychain::Scope] a new scope object
     def generic_passwords
       Scope.new(Sec::Classes::GENERIC, self)
+    end
+
+    # Imports item from string or file to this keychain
+    #
+    # @param [IO, String] input IO object or String with raw data to import
+    # @param [Array <String>] app_list List of applications which will be
+    # permitted to access imported items
+    # @return [Array <SecKeychainItem>] List of imported keychain objects,
+    # each of which may be a SecCertificate, SecKey, or SecIdentity instance
+    def import(input, app_list=[])
+      input = input.read if input.is_a? IO
+
+      # Create array of TrustedApplication objects
+      trusted_apps = get_trusted_apps(app_list)
+
+      # Create an Access object
+      access_buffer = FFI::MemoryPointer.new(:pointer)
+      status = Sec.SecAccessCreate(path.to_cf, trusted_apps, access_buffer)
+      Sec.check_osstatus status
+      access = CF::Base.typecast(access_buffer.read_pointer).release_on_gc
+
+      key_params = Sec::SecItemImportExportKeyParameters.new
+      key_params[:accessRef] = access
+
+      # Import item to the keychain
+      cf_data = CF::Data.from_string(input).release_on_gc
+      cf_array = FFI::MemoryPointer.new(:pointer)
+      status = Sec.SecItemImport(cf_data, nil, :kSecFormatUnknown, :kSecItemTypeUnknown, :kSecItemPemArmour, key_params, self, cf_array)
+      Sec.check_osstatus status
+      item_array = CF::Base.typecast(cf_array.read_pointer).release_on_gc
+
+      item_array.to_ruby
     end
 
     # returns a description of the keychain
@@ -203,6 +246,17 @@ module Keychain
       status = Sec.SecKeychainCopySettings(self, settings)
       Sec.check_osstatus status
       settings
+    end
+
+    def get_trusted_apps apps
+      trusted_app_array = apps.map do |path|
+        trusted_app_buffer = FFI::MemoryPointer.new(:pointer)
+        status = Sec.SecTrustedApplicationCreateFromPath(
+          path.encode(Encoding::UTF_8), trusted_app_buffer)
+        Sec.check_osstatus(status)
+        CF::Base.typecast(trusted_app_buffer.read_pointer).release_on_gc
+      end
+      trusted_app_array.to_cf
     end
 
     def put_settings settings

--- a/lib/keychain/keychain.rb
+++ b/lib/keychain/keychain.rb
@@ -1,5 +1,12 @@
 
 module Sec
+  enum :SecExternalItemType, [:kSecItemTypeUnknown ,
+                              :kSecItemTypePrivateKey,
+                              :kSecItemTypePublicKey,
+                              :kSecItemTypeSessionKey,
+                              :kSecItemTypeCertificate,
+                              :kSecItemTypeAggregate]
+
   attach_function 'SecKeychainCopyDefault', [:pointer], :osstatus
   attach_function 'SecKeychainDelete', [:keychainref], :osstatus
   attach_function 'SecKeychainOpen', [:string, :pointer], :osstatus


### PR DESCRIPTION
I've tried to implement import of Keychain Items from both the row `File` and `String` instances. 
I'm very new to this stuff and I haven't managed to allow trusting to all applications yet.

@fcheung Please, review this code and give recommendations what I have to change here. I would be grateful if you could help me with that.

Currently it is working for me this way:
```ruby
irb(main):005:0> require 'keychain'
=> true
irb(main):006:0> kc = Keychain.create('/tmp/test.keychain', 'secretpass')
=> <SecKeychain 0x7fb39bda0810: /private/tmp/test.keychain>
irb(main):007:0> kc.unlock!('secretpass')
=> nil
irb(main):008:0> kc.import(File.open('/path/to/some.key'), ['/usr/bin/security', '/usr/bin/codesign'])
=> nil
> Keychain::Scope.new(Sec::Classes::KEY, kc).all
=> [<SecKey 0x7fb39e910590 [0x7fff7968bed0]>]
```