### PR TITLE
fix a module not defined error and ignore .gem files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .rbx
 Gemfile.lock
 .yardoc
+*.gem

--- a/lib/keychain/keychain.rb
+++ b/lib/keychain/keychain.rb
@@ -29,14 +29,6 @@ module Sec
             :lock_interval, :uint32
   end
 
-  class Keychain::TrustedApplication < Sec::Base
-    register_type 'SecTrustedApplication'
-  end
-
-  class Keychain::Access < Sec::Base
-    register_type 'SecAccess'
-  end
-
   attach_function 'SecKeychainSetSettings', [:keychainref, KeychainSettings], :osstatus
   attach_function 'SecKeychainCopySettings', [:keychainref, KeychainSettings], :osstatus
 
@@ -56,6 +48,14 @@ module Sec
 end
 
 module Keychain
+  class TrustedApplication < Sec::Base
+    register_type 'SecTrustedApplication'
+  end
+
+  class Access < Sec::Base
+    register_type 'SecAccess'
+  end
+
   # Wrapper class for individual keychains. Corresponds to a SecKeychainRef
   #
   class Keychain < Sec::Base


### PR DESCRIPTION
With the latest 0.3.0, I was getting an exception because a module was trying to be used before it had been defined.  I have fixed this exception by moving the class definitions into the module definition instead of using the module::class syntax.