### PR TITLE
Allow Updating Keys and Certificates in a KeyChain

### DIFF
--- a/lib/keychain/item.rb
+++ b/lib/keychain/item.rb
@@ -1,8 +1,6 @@
 
 module Sec
   attach_function 'SecKeychainItemDelete', [:pointer], :osstatus
-  attach_function 'SecItemAdd', [:pointer, :pointer], :osstatus
-  attach_function 'SecItemUpdate', [:pointer, :pointer], :osstatus
   attach_function 'SecKeychainItemCopyKeychain', [:pointer, :pointer], :osstatus
 end
 
@@ -129,19 +127,6 @@ module Keychain
       cf_dict = CF::Base.typecast(result.read_pointer)
     end
 
-    def update
-      status = Sec.SecItemUpdate({Sec::Query::SEARCH_LIST => [self.keychain],
-                                  Sec::Query::ITEM_LIST => [self],
-                                  Sec::Query::CLASS => klass}.to_cf, build_new_attributes);
-      Sec.check_osstatus(status)
-
-      result = FFI::MemoryPointer.new :pointer
-      query = build_refresh_query
-      status = Sec.SecItemCopyMatching(query, result);
-      Sec.check_osstatus(status)
-      cf_dict = CF::Base.typecast(result.read_pointer)
-    end
-      
     def build_create_query options
       query = CF::Dictionary.mutable
       query[Sec::Value::DATA] = CF::Data.from_string(@unsaved_password) if @unsaved_password
@@ -151,24 +136,8 @@ module Keychain
       query
     end
 
-    def build_refresh_query
-      query = CF::Dictionary.mutable
-      query[Sec::Query::SEARCH_LIST] = CF::Array.immutable([self.keychain])
-      query[Sec::Query::ITEM_LIST] = CF::Array.immutable([self])
-      query[Sec::Query::RETURN_ATTRIBUTES] = CF::Boolean::TRUE
-      query[Sec::Query::RETURN_REF] = CF::Boolean::TRUE
-      query[Sec::Query::CLASS] = klass.to_cf
-      query
-    end
-
     def build_new_attributes
-      new_attributes = CF::Dictionary.mutable
-      @attributes.each do |k,v|
-        next if k == :created_at || k == :updated_at
-        next if k == :klass && persisted?
-        k = self.class::INVERSE_ATTR_MAP[k]
-        new_attributes[k] = v.to_cf
-      end
+      new_attributes = super
       new_attributes[Sec::Value::DATA] = CF::Data.from_string(@unsaved_password) if @unsaved_password
       new_attributes
     end

--- a/lib/keychain/keychain.rb
+++ b/lib/keychain/keychain.rb
@@ -16,8 +16,11 @@ module Sec
   attach_function 'SecKeychainGetPath', [:keychainref, :pointer, :pointer], :osstatus
 
   attach_function 'SecKeychainCreate', [:string, :uint32, :pointer, :char, :pointer, :pointer], :osstatus
+
+  attach_function 'SecItemAdd', [:pointer, :pointer], :osstatus
   attach_function 'SecItemCopyMatching', [:pointer, :pointer], :osstatus
-  
+  attach_function 'SecItemUpdate', [:pointer, :pointer], :osstatus
+
   attach_function 'SecKeychainSetSearchList', [:pointer], :osstatus
   attach_function 'SecKeychainCopySearchList', [:pointer], :osstatus
 


### PR DESCRIPTION
The goal of this patch is to enable updating keys and certificates stored in a key chain. It does this by moving access to SecItemUpdate to the Sec::Base class.  This was inspired by the section “Adding, Removing, and Working With Keys and Certificates” in the Key Services Programming Guide which mentions SecItemAdd, SecItemUpdate and SecItemCopyMatching as base functions that should be used on keys and certificates stored in the KeyChain.  This patch does make it possible for example to change a key’s name as stored in the keychain (my particular use case).