### PR TITLE
Fix pkcs12 export

### DIFF
--- a/lib/keychain/identity.rb
+++ b/lib/keychain/identity.rb
@@ -37,7 +37,7 @@ module Keychain
       Key.new(key_ref.read_pointer).release_on_gc
     end
 
-    def pkcs12(passphrase='')
+    def pkcs12(passphrase = '')
       flags = Sec::SecItemImportExportKeyParameters.new
       flags[:version] = Sec::SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION
       flags[:passphrase] = CF::String.from_string(passphrase).to_ptr
@@ -47,7 +47,7 @@ module Keychain
       Sec.check_osstatus(status)
 
       data = CF::Data.new(data_ptr.read_pointer)
-      result = OpenSSL::PKCS12.new(data.to_s)
+      result = OpenSSL::PKCS12.new(data.to_s, passphrase)
       data.release
       result
     end


### PR DESCRIPTION
**Issue**: passphrase not being passed openssl parser results in `OpenSSL::PKCS12::PKCS12Error (PKCS12_parse: mac verify failure)`
**Fix**: Pass `passphrase` to pkcs12 parser