### PR TITLE
try upgrading to cf 0.3

### DIFF
--- a/keychain.gemspec
+++ b/keychain.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency "ffi"
-  s.add_runtime_dependency "corefoundation", "~> 0.2.0"
+  s.add_runtime_dependency "corefoundation", "~> 0.3.0"
   s.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
   s.add_development_dependency "rake", '~> 13'
   s.add_development_dependency "yard", '~> 0.9.11'

--- a/lib/keychain.rb
+++ b/lib/keychain.rb
@@ -36,7 +36,7 @@ module Keychain
       end
 
       Sec.check_osstatus(status)
-      Keychain.new(out_buffer.read_pointer).release_on_gc
+      Keychain.new(out_buffer.read_pointer)
     end
 
     # Gets the default keychain object ( SecKeychainCopyDefault )
@@ -48,7 +48,7 @@ module Keychain
       status = Sec.SecKeychainCopyDefault(out_buffer);
       Sec.check_osstatus(status)
 
-      Keychain.new(out_buffer.read_pointer).release_on_gc
+      Keychain.new(out_buffer.read_pointer)
     end
 
     # Opens the keychain file at the specified path and adds it to the keychain search path ( SecKeychainOpen )
@@ -63,7 +63,7 @@ module Keychain
       out_buffer = FFI::MemoryPointer.new(:pointer)
       status = Sec.SecKeychainOpen(path,out_buffer);
       Sec.check_osstatus(status)
-      Keychain.new(out_buffer.read_pointer).release_on_gc
+      Keychain.new(out_buffer.read_pointer)
     end
 
     # Returns a scope for internet passwords contained in all keychains

--- a/lib/keychain/certificate.rb
+++ b/lib/keychain/certificate.rb
@@ -44,7 +44,7 @@ module Keychain
       status = Sec.SecCertificateCopyPublicKey(self, key_ref)
       Sec.check_osstatus(status)
 
-      Key.new(key_ref.read_pointer).release_on_gc
+      Key.new(key_ref.read_pointer)
     end
 
     def x509
@@ -52,7 +52,6 @@ module Keychain
       data = CF::Data.new(data_ptr)
 
       result = OpenSSL::X509::Certificate.new(data.to_s)
-      data.release
       result
     end
   end

--- a/lib/keychain/identity.rb
+++ b/lib/keychain/identity.rb
@@ -26,7 +26,7 @@ module Keychain
       status = Sec.SecIdentityCopyCertificate(self, certificate_ref)
       Sec.check_osstatus(status)
 
-      Certificate.new(certificate_ref.read_pointer).release_on_gc
+      Certificate.new(certificate_ref.read_pointer)
     end
 
     def private_key
@@ -34,7 +34,7 @@ module Keychain
       status = Sec.SecIdentityCopyPrivateKey(self, key_ref)
       Sec.check_osstatus(status)
 
-      Key.new(key_ref.read_pointer).release_on_gc
+      Key.new(key_ref.read_pointer)
     end
 
     def pkcs12(passphrase = '')

--- a/lib/keychain/identity.rb
+++ b/lib/keychain/identity.rb
@@ -48,7 +48,6 @@ module Keychain
 
       data = CF::Data.new(data_ptr.read_pointer)
       result = OpenSSL::PKCS12.new(data.to_s, passphrase)
-      data.release
       result
     end
   end

--- a/lib/keychain/item.rb
+++ b/lib/keychain/item.rb
@@ -99,11 +99,12 @@ module Keychain
       else
         cf_dict = create(options)
         self.ptr = cf_dict[Sec::Value::REF].to_ptr
-        self.retain.release_on_gc
+        # the originally installed finalizer will be using the original (zero) value of ptr
+        self.retain
+        ObjectSpace.define_finalizer(self, self.class.finalize(self.ptr))
       end
       @unsaved_password = nil
       update_self_from_dictionary(cf_dict)
-      cf_dict.release
       self
     end
 

--- a/lib/keychain/item.rb
+++ b/lib/keychain/item.rb
@@ -85,7 +85,7 @@ module Keychain
                                         Sec::Query::CLASS => self.klass,
                                         Sec::Query::RETURN_DATA => true}.to_cf, out_buffer)
       Sec.check_osstatus(status)
-      CF::Base.typecast(out_buffer.read_pointer).release_on_gc.to_s
+      CF::Base.typecast(out_buffer.read_pointer).to_s
     end
 
     # Attempts to update the keychain with any changes made to the item

--- a/lib/keychain/key.rb
+++ b/lib/keychain/key.rb
@@ -109,7 +109,6 @@ module Keychain
 
       data = CF::Data.new(data_ptr.read_pointer)
       result = data.to_s
-      data.release
       result
     end
   end

--- a/lib/keychain/keychain.rb
+++ b/lib/keychain/keychain.rb
@@ -61,7 +61,7 @@ module Keychain
       list = FFI::MemoryPointer.new(:pointer)
       status = Sec.SecKeychainCopySearchList(list)
       Sec.check_osstatus(status)
-      ruby_list = CF::Base.typecast(list.read_pointer).release_on_gc.to_ruby
+      ruby_list = CF::Base.typecast(list.read_pointer).to_ruby
       ruby_list << self unless ruby_list.include?(self)
       status = Sec.SecKeychainSetSearchList(CF::Array.immutable(ruby_list))
       Sec.check_osstatus(status)
@@ -136,12 +136,11 @@ module Keychain
       key_params[:accessRef] = access
 
       # Import item to the keychain
-      cf_data = CF::Data.from_string(input).release_on_gc
+      cf_data = CF::Data.from_string(input)
       cf_array = FFI::MemoryPointer.new(:pointer)
       status = Sec.SecItemImport(cf_data, nil, :kSecFormatUnknown, :kSecItemTypeUnknown, :kSecItemPemArmour, key_params, self, cf_array)
-      access.release
       Sec.check_osstatus status
-      item_array = CF::Base.typecast(cf_array.read_pointer).release_on_gc
+      item_array = CF::Base.typecast(cf_array.read_pointer)
 
       item_array.to_ruby
     end
@@ -248,7 +247,7 @@ module Keychain
         status = Sec.SecTrustedApplicationCreateFromPath(
           path.encode(Encoding::UTF_8), trusted_app_buffer)
         Sec.check_osstatus(status)
-        CF::Base.typecast(trusted_app_buffer.read_pointer).release_on_gc
+        CF::Base.typecast(trusted_app_buffer.read_pointer)
       end
       trusted_app_array.to_cf
     end

--- a/lib/keychain/scope.rb
+++ b/lib/keychain/scope.rb
@@ -107,7 +107,7 @@ class Keychain::Scope
       return []
     end
     Sec.check_osstatus(status)
-    result = CF::Base.typecast(result.read_pointer).release_on_gc
+    result = CF::Base.typecast(result.read_pointer)
     unless result.is_a?(CF::Array)
       result = CF::Array.immutable([result])
     end

--- a/lib/keychain/sec.rb
+++ b/lib/keychain/sec.rb
@@ -151,7 +151,7 @@ module Sec
       out = FFI::MemoryPointer.new :pointer
       status = Sec.SecKeychainItemCopyKeychain(self,out)
       Sec.check_osstatus(status)
-      CF::Base.new(out.read_pointer).release_on_gc
+      CF::Base.new(out.read_pointer)
     end
 
     def load_attributes
@@ -163,7 +163,7 @@ module Sec
                                         Sec::Query::RETURN_REF => false}.to_cf, result)
       Sec.check_osstatus(status)
 
-      cf_dict = CF::Base.typecast(result.read_pointer).release_on_gc
+      cf_dict = CF::Base.typecast(result.read_pointer)
       update_self_from_dictionary(cf_dict)
     end
   end


### PR DESCRIPTION
this changes the memory management model somewhat:
- we don't need to release (or rather the manual release is now an overrelease
- release_on_gc doesn't exist anymore
