### PR TITLE
CI: add manual trigger; new Ruby versions; etc.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
 name: CI
 on:
+  workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ master switch-cf-gem ]
   pull_request:
-    branches: [ master ]
+    branches: [ master switch-cf-gem ]
 jobs:
   build:
     runs-on: macos-latest
@@ -17,4 +18,4 @@ jobs:
       - run: bundle exec rake
     strategy:
       matrix:
-        ruby: ['2.6.9', '2.7.3', '3.1.1', '3.0.3']
+        ruby: ['2.6.10', '2.7.6', '3.1.2', '3.0.4']

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .rbx
 Gemfile.lock
 .yardoc
+secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .rbx
 Gemfile.lock
 .yardoc
-secrets.yml


### PR DESCRIPTION
I updated to the newest Ruby versions, added the ability to trigger the build manually and included the switch-cf-gem branch in the CI process, because I was interested to see if that branch was building OK (it is not).